### PR TITLE
google analytics 4 migration

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -11,14 +11,14 @@
 		{% if page.has_highlighting %}<link rel="stylesheet" href="/syntax-highlighting.css">{% endif %}
 		{% if page.has_math %}<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" async></script>{% endif %}
 		{% unless page.no_analytics %}
+		<!-- Google tag (gtag.js) -->
+		<script async src="https://www.googletagmanager.com/gtag/js?id=G-MPMZDP3LR7"></script>
 		<script>
-			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-			})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+			window.dataLayer = window.dataLayer || [];
+			function gtag(){dataLayer.push(arguments);}
+			gtag('js', new Date());
 
-			ga('create', 'UA-68706725-1', 'auto');
-			ga('send', 'pageview');
+			gtag('config', 'G-MPMZDP3LR7');
 		</script>
 		{% endunless %}
 	</head>


### PR DESCRIPTION
https://support.google.com/analytics/answer/10759417?hl=en

they won't be able to work with "analytics.js" in July.

| | analytics.js | gtag/js |
|--|--:|--:|
| size (transfer) | 20.62 kB | 84.25 kB |
| size (decompressed) | 50.23 kB | 274.56 kB |
| cacheability | constant URL | unique URL |