### PR TITLE
layouts: new opinion on viewport string (cosmetic)

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width,initial-scale=1">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>{{ page.title | smartify }}</title>
 		<link rel="icon" href="{{ site.icon }}">
 		<link rel="stylesheet" href="/omni.css">


### PR DESCRIPTION
alright after some amount of research, I've concluded that having a space is normal. the rest of the code is not particularly condensed either, so let's have a space

* github: `<meta name="viewport" content="width=device-width">` no opinion either way. actually the lack of initial-scale is kind of annoying, with the zoom jumping around while the page loads. side note, google crawlers don't respect inital-scale
* gitlab: `<meta content="width=device-width, initial-scale=1" name="viewport">` yes space
* hacker news: `<meta name="viewport" content="width=device-width, initial-scale=1.0">` yes space. also one-point-zero scale
* apple: `<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />` yes space. has some newfangled viewport-fit thing too. also it's an xhtml document, so they have a self-close slash
* mozilla: `<meta name="viewport" content="width=device-width, initial-scale=1">` yes space
* google: absent in html, something later adds `<meta content="width=device-width,minimum-scale=1.0" name="viewport">` no space. point-zero
* google accounts: `<meta name="viewport" content="width=device-width, initial-scale=1">` yes space
* gmail: `<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, width=device-width">` yes space. point-zero. 
* bing: `<meta name="viewport" content="width=device-width, initial-scale=1.0" />` yes space. slash, even though it's an html document, bleh. point-zero
* microsoft: `<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>` yes space. has some shrink-to-fit thing. slash, even though it's an html document. no space before slash
* debian: `<meta name="viewport" content="width=device-width">` no opinion
* nintendo: `<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=yes"/>` yes space. has some user-scalable thing. slash, even though it's an html document. no space before slash
* facebook login: `<meta name="viewport" content="user-scalable=no,initial-scale=1,maximum-scale=1" />` no space. no width set. slash, even though it's an html document
* facebook: `<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=2,shrink-to-fit=no" />` no space. maximum-scale set
* gmail: `<meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, width=device-width">` yes space. width at the end instead of the beginning. point-zero. absolutely no scaling, don't you dare, never go higher or lower than 1.0
* youtube: `<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no,">` yes space. point-zero. trailing comma wow
* mdn article sample: `<meta name="viewport" content="width=device-width, initial-scale=1.0" />` yes space. point-zero. slash
* mdn page itself:
   ```html
             <meta
               name="viewport"
               content="width=device-width, initial-scale=1.0"
             />
   ```
   yes space. point-zero. slash, even though it's an html document. now we're cooking with whitespace
