### PR TITLE
config: change to one of those city time zones

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ defaults:
       type: drafts
     values:
       layout: post
-timezone: US/Pacific
+timezone: America/Los_Angeles
 icon: https://avatars.githubusercontent.com/u/382796?v=3
 feed_author_name: w
 feed_base: https://wh0.github.io


### PR DESCRIPTION
it's said that these US/(some time zone name) time zones are from a "backward" section. the one we had, `US/Pacific`, is a link to `America/Los_Angeles`. we might as well just use the latter