### PR TITLE
add blockquote line

### DIFF
--- a/omni.css
+++ b/omni.css
@@ -17,6 +17,14 @@ a:visited {
 	color: #702090;
 }
 
+blockquote {
+	margin-left: 0px;
+	margin-right: 0px;
+	border-left: 4px solid #e0e0e0;
+	padding-left: 2.25rem;
+	padding-right: 2.5rem;
+}
+
 hr {
 	margin: 1rem auto;
 	border: medium none;


### PR DESCRIPTION
lotta markdown-accepting services (github, slack, discord) have this line on the left of block quotes

this formulation leaves the overall layout the same. it eats up some of the left padding with a border. padding derived from browser default styles (browser default styles use margin instead of padding though)

<img width="515" height="211" alt="image" src="https://github.com/user-attachments/assets/7074c010-ba8a-4507-a790-c4ba80ebc85d" />
