### PR TITLE
add horizontal padding to inline code

### DIFF
--- a/omni.css
+++ b/omni.css
@@ -25,12 +25,20 @@ blockquote {
 	padding-right: 2.5rem;
 }
 
+code {
+	padding: 0px 3px;
+}
+
 hr {
 	margin: 1rem auto;
 	border: medium none;
 	border-top: 1px solid;
 	width: 50%;
 	color: #e0e0e0;
+}
+
+pre code {
+	padding: 0px;
 }
 
 table {


### PR DESCRIPTION
when there's spaces around inline code that has spaces, the spaces around it are narrower than the spaces inside, which is, like, bad information hierarchy

> <img width="592" height="48" alt="image" src="https://github.com/user-attachments/assets/0fec00d3-e20f-4335-aa12-adb2529455b5" />

tried doing some measurements but the antialiasing makes it kind of iffy

<img width="860" height="234" alt="image" src="https://github.com/user-attachments/assets/bfaa6f95-58f8-4c45-bcec-d872fe7ef5da" />

:point_up: "HH HH `HH HH`" rendered at 160px, i.e. 10x size. source sans 3 and deja vu sans mono

distances between glyph edges:

* source sans 3 <-> source sans 3: 61px
* source sans 3 <-> deja vu sans mono: 54px
* deja vu sans mono <-> deja vu sans mono: 88px

so we'd need to add ~34px padding on the `<code>` for the boundary space to be at least as wide as a space within. that would be ~3.4px at 1x size. this PR rounds to 3px which looks ok.

> <img width="592" height="48" alt="image" src="https://github.com/user-attachments/assets/8305fc35-a37b-4ee0-93f9-2a52e52fe041" />
