### PR TITLE
sync syntax highlight style from upstream

### DIFF
--- a/syntax-highlighting.scss
+++ b/syntax-highlighting.scss
@@ -1,67 +1,76 @@
 ---
 ---
 // from Minima, used under MIT License
-/**
- * Syntax highlighting styles
- */
 .highlight {
-    .c     { color: #998; font-style: italic } // Comment
-    .err   { color: #a61717; background-color: #e3d2d2 } // Error
-    .k     { font-weight: bold } // Keyword
-    .o     { font-weight: bold } // Operator
-    .cm    { color: #998; font-style: italic } // Comment.Multiline
-    .cp    { color: #999; font-weight: bold } // Comment.Preproc
-    .c1    { color: #998; font-style: italic } // Comment.Single
-    .cs    { color: #999; font-weight: bold; font-style: italic } // Comment.Special
-    .gd    { color: #000; background-color: #fdd } // Generic.Deleted
-    .gd .x { color: #000; background-color: #faa } // Generic.Deleted.Specific
-    .ge    { font-style: italic } // Generic.Emph
-    .gr    { color: #a00 } // Generic.Error
-    .gh    { color: #999 } // Generic.Heading
-    .gi    { color: #000; background-color: #dfd } // Generic.Inserted
-    .gi .x { color: #000; background-color: #afa } // Generic.Inserted.Specific
-    .go    { color: #888 } // Generic.Output
-    .gp    { color: #555 } // Generic.Prompt
-    .gs    { font-weight: bold } // Generic.Strong
-    .gu    { color: #aaa } // Generic.Subheading
-    .gt    { color: #a00 } // Generic.Traceback
-    .kc    { font-weight: bold } // Keyword.Constant
-    .kd    { font-weight: bold } // Keyword.Declaration
-    .kp    { font-weight: bold } // Keyword.Pseudo
-    .kr    { font-weight: bold } // Keyword.Reserved
-    .kt    { color: #458; font-weight: bold } // Keyword.Type
-    .m     { color: #099 } // Literal.Number
-    .s     { color: #d14 } // Literal.String
-    .na    { color: #008080 } // Name.Attribute
-    .nb    { color: #0086B3 } // Name.Builtin
-    .nc    { color: #458; font-weight: bold } // Name.Class
-    .no    { color: #008080 } // Name.Constant
-    .ni    { color: #800080 } // Name.Entity
-    .ne    { color: #900; font-weight: bold } // Name.Exception
-    .nf    { color: #900; font-weight: bold } // Name.Function
-    .nn    { color: #555 } // Name.Namespace
-    .nt    { color: #000080 } // Name.Tag
-    .nv    { color: #008080 } // Name.Variable
-    .ow    { font-weight: bold } // Operator.Word
-    .w     { color: #bbb } // Text.Whitespace
-    .mf    { color: #099 } // Literal.Number.Float
-    .mh    { color: #099 } // Literal.Number.Hex
-    .mi    { color: #099 } // Literal.Number.Integer
-    .mo    { color: #099 } // Literal.Number.Oct
-    .sb    { color: #d14 } // Literal.String.Backtick
-    .sc    { color: #d14 } // Literal.String.Char
-    .sd    { color: #d14 } // Literal.String.Doc
-    .s2    { color: #d14 } // Literal.String.Double
-    .se    { color: #d14 } // Literal.String.Escape
-    .sh    { color: #d14 } // Literal.String.Heredoc
-    .si    { color: #d14 } // Literal.String.Interpol
-    .sx    { color: #d14 } // Literal.String.Other
-    .sr    { color: #009926 } // Literal.String.Regex
-    .s1    { color: #d14 } // Literal.String.Single
-    .ss    { color: #990073 } // Literal.String.Symbol
-    .bp    { color: #999 } // Name.Builtin.Pseudo
-    .vc    { color: #008080 } // Name.Variable.Class
-    .vg    { color: #008080 } // Name.Variable.Global
-    .vi    { color: #008080 } // Name.Variable.Instance
-    .il    { color: #099 } // Literal.Number.Integer.Long
+  .err   { color: #e3d2d2; background-color: #a61717 } // Error
+
+  .c     { color: #9c9996 } // Comment
+  .cm    { color: #9c9996 } // Comment.Multiline
+  .cp    { color: #9c9996 } // Comment.Preproc
+  .c1    { color: #9c9996 } // Comment.Single
+  .cs    { color: #9c9996; font-style: italic } // Comment.Special
+
+  .gd    { color: #e25050 } // Generic.Deleted
+  .gd .x { color: #e25050 } // Generic.Deleted.Specific
+  .ge    { font-style: italic } // Generic.Emph
+  .gh    { color: #999999 } // Generic.Heading
+  .gi    { color: #3f993f } // Generic.Inserted
+  .gi .x { color: #3f993f } // Generic.Inserted.Specific
+  .go    { color: #888888 } // Generic.Output
+  .gp    { color: #555555 } // Generic.Prompt
+  .gr    { color: #aa0000 } // Generic.Error
+  .gs    { font-weight: bold } // Generic.Strong
+  .gt    { color: #aa0000 } // Generic.Traceback
+  .gu    { color: #aaaaaa } // Generic.Subheading
+
+  .k     { color: #cf222e } // Keyword
+  .kc    { color: #cf222e } // Keyword.Constant
+  .kd    { color: #cf222e } // Keyword.Declaration
+  .kp    { color: #cf222e } // Keyword.Pseudo
+  .kr    { color: #cf222e } // Keyword.Reserved
+  .kt    { color: #445588 } // Keyword.Type
+
+  .n     { color: #111111 }
+  .na    { color: #097e39 } // Name.Attribute
+  .nb    { color: #cf222e } // Name.Builtin
+  .bp    { color: #999999 } // Name.Builtin.Pseudo
+  .nc    { color: #097e39 } // Name.Class
+  .ne    { color: #990000 } // Name.Exception
+  .nf    { color: #2c7d74 } // Name.Function
+  .ni    { color: #097e39 } // Name.Entity
+  .nn    { color: #097e39 } // Name.Namespace
+  .no    { color: #a61154 } // Name.Constant
+  .nt    { color: #b81e63 } // Name.Tag
+  .nv    { color: #752a75 } // Name.Variable
+  .vc    { color: #752a75 } // Name.Variable.Class
+  .vg    { color: #752a75 } // Name.Variable.Global
+  .vi    { color: #752a75 } // Name.Variable.Instance
+
+  .o     { color: #0842a0 } // Operator
+  .ow    { color: #0842a0 } // Operator.Word
+
+  .m     { color: #005a99 } // Literal.Number
+  .mf    { color: #005a99 } // Literal.Number.Float
+  .mh    { color: #005a99 } // Literal.Number.Hex
+  .mi    { color: #005a99 } // Literal.Number.Integer
+  .il    { color: #005a99 } // Literal.Number.Integer.Long
+  .mo    { color: #005a99 } // Literal.Number.Oct
+
+  .s     { color: #914d08 } // Literal.String
+  .s1    { color: #914d08 } // Literal.String.Single
+  .s2    { color: #914d08 } // Literal.String.Double
+  .sb    { color: #914d08 } // Literal.String.Backtick
+  .sc    { color: #914d08 } // Literal.String.Char
+  .sd    { color: #914d08 } // Literal.String.Doc
+  .se    { color: #914d08 } // Literal.String.Escape
+  .sh    { color: #914d08 } // Literal.String.Heredoc
+  .si    { color: #914d08 } // Literal.String.Interpol
+  .sr    { color: #009926 } // Literal.String.Regex
+  .ss    { color: #0842a0 } // Literal.String.Symbol
+  .sx    { color: #914d08 } // Literal.String.Other
+
+  .w     { color: #bbbbbb } // Text.Whitespace
+
+  .lineno, .gl { color: #9c9996 } // Line Number
+  .hll   { background-color: #ffffcc } // Marked-lines
 }


### PR DESCRIPTION
actually now that we know these styles are from minima, it's easy to find out that minima updated its syntax highlighting theme

before

> <img width="592" height="216" alt="image" src="https://github.com/user-attachments/assets/b108b172-06eb-463e-908a-ff5bf963e24f" />

after

> <img width="592" height="216" alt="image" src="https://github.com/user-attachments/assets/79399513-0acf-4e60-a0ea-45897b7b57f2" />

looks ok, more colorful. I'm going to miss strings being in red. but generally we didn't have our own style so let's follow upstream